### PR TITLE
Fix missing Prettier ESLint plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "format": "prettier --write 'src/**/*.{ts,tsx,scss}'"
   },
+  "devDependencies": {
+    "eslint-plugin-prettier": "^5.0.1",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.1.0"
+  },
   "eslintConfig": {
     "extends": ["react-app", "react-app/jest"]
   },


### PR DESCRIPTION
## Summary
- add eslint-plugin-prettier and related dev dependencies

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867722238908328b483cd7493a65cd0