### PR TITLE
Add dashboard boilerplate with theme and sample components

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/react-webpack5';
+
+const config: StorybookConfig = {
+  stories: ['../src/stories/**/*.stories.@(ts|tsx)'],
+  addons: [
+    '@storybook/addon-actions',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-webpack5',
+    options: {},
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,9 @@
+import type { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on.*' },
+  },
+};
+
+export default preview;

--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 
 This project was bootstrapped with the Create React App TypeScript template.
 It uses **SCSS** for styling and includes ESLint with Prettier integration.
-The project now features a simple Material UI theme with a light/dark
-toggle powered by `@mui/material`.
-Use the "Toggle Theme" button in the header to switch between light and
-dark modes during runtime.
+The project now provides a simple dashboard layout with authentication
+and a Material UI theme extracted from the provided logo colors. A light
+and dark mode can be toggled from the header.
+
+Additional demo features include a data grid, chart, file upload and a
+rich text editor. Storybook is configured under the `storybook` npm
+script to preview UI components in isolation.
+
+### Theming
+
+Colors are derived from `src/Asset/MCX_Logo.png`. To change branding,
+update the palettes in `src/theme.ts` and restart the application.
 
 ## Available Scripts
 
@@ -30,6 +38,14 @@ Runs ESLint over the `src` directory.
 ### `npm run format`
 
 Formats source files using Prettier.
+
+### `npm run storybook`
+
+Starts Storybook to preview components.
+
+### `npm run test:coverage`
+
+Runs tests with a coverage report.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -20,20 +20,39 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "sass": "^1.70.0",
-    "web-vitals": "^3.3.0"
+    "web-vitals": "^3.3.0",
+    "axios": "^1.4.0",
+    "react-router-dom": "^6.20.0",
+    "@mui/icons-material": "^5.14.0",
+    "@mui/x-data-grid": "^6.7.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0",
+    "react-dropzone": "^14.2.3",
+    "@ckeditor/ckeditor5-react": "^5.1.0",
+    "@ckeditor/ckeditor5-build-classic": "^39.0.1",
+    "react-hot-toast": "^2.4.1",
+    "react-spinners": "^0.13.8"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:coverage": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "format": "prettier --write 'src/**/*.{ts,tsx,scss}'"
+    "format": "prettier --write 'src/**/*.{ts,tsx,scss}'",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
   },
   "devDependencies": {
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-config-prettier": "^9.1.0",
-    "prettier": "^3.1.0"
+    "prettier": "^3.1.0",
+    "@storybook/react": "^7.6.3",
+    "@storybook/addon-actions": "^7.6.3",
+    "@storybook/addon-essentials": "^7.6.3",
+    "@storybook/addon-interactions": "^7.6.3",
+    "@storybook/testing-react": "^2.2.1"
   },
   "eslintConfig": {
     "extends": ["react-app", "react-app/jest"]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,53 @@
 import React, { useState } from 'react';
-import logo from './logo.svg';
-import './App.scss';
-import { ThemeProvider, CssBaseline, Button, Box } from '@mui/material';
-import { lightTheme, darkTheme } from './theme';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { CssBaseline, Box } from '@mui/material';
+import Sidebar from './components/Sidebar';
+import Header from './components/Header';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import Landing from './pages/Landing';
+import Profile from './pages/Profile';
+import ProtectedRoute from './components/ProtectedRoute';
+import { AuthProvider } from './contexts/AuthContext';
+import { ThemeModeProvider } from './theme';
+import toast, { Toaster } from 'react-hot-toast';
 
 function App() {
-  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <ThemeProvider theme={mode === 'light' ? lightTheme : darkTheme}>
-      <CssBaseline />
-      <Box className="App" textAlign="center" p={4}>
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <p>
-            Edit <code>src/App.tsx</code> and save to reload.
-          </p>
-          <Button
-            variant="contained"
-            onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
-          >
-            Toggle Theme
-          </Button>
-        </header>
-      </Box>
-    </ThemeProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <CssBaseline />
+        <Router>
+          <Header onMenuClick={() => setSidebarOpen(true)} />
+          <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+          <Box component="main" mt={2}>
+            <Routes>
+              <Route path="/" element={<Landing />} />
+              <Route path="/login" element={<Login />} />
+              <Route
+                path="/dashboard"
+                element={
+                  <ProtectedRoute>
+                    <Dashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/profile"
+                element={
+                  <ProtectedRoute>
+                    <Profile />
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </Box>
+        </Router>
+        <Toaster position="top-right" />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
 }
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api',
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/src/components/ExampleButton.tsx
+++ b/src/components/ExampleButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Button } from '@mui/material';
+
+export interface ExampleButtonProps {
+  label: string;
+  onClick?: () => void;
+}
+
+const ExampleButton = ({ label, onClick }: ExampleButtonProps) => (
+  <Button variant="contained" onClick={onClick}>
+    {label}
+  </Button>
+);
+
+export default ExampleButton;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, IconButton, Switch } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import { useThemeMode } from '../theme';
+import { useAuth } from '../contexts/AuthContext';
+
+interface Props {
+  onMenuClick: () => void;
+}
+
+const Header = ({ onMenuClick }: Props) => {
+  const { mode, toggleMode } = useThemeMode();
+  const { logout } = useAuth();
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <IconButton edge="start" color="inherit" onClick={onMenuClick}>
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Dashboard
+        </Typography>
+        <Switch checked={mode === 'dark'} onChange={toggleMode} />
+        <IconButton color="inherit" onClick={logout}>
+          Logout
+        </IconButton>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ClipLoader } from 'react-spinners';
+
+const Loader = () => (
+  <div style={{ display: 'flex', justifyContent: 'center', padding: '2rem' }}>
+    <ClipLoader />
+  </div>
+);
+
+export default Loader;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+interface Props {
+  children: JSX.Element;
+}
+
+const ProtectedRoute = ({ children }: Props) => {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Drawer, List, ListItem, ListItemText } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const Sidebar = ({ open, onClose }: Props) => (
+  <Drawer open={open} onClose={onClose}>
+    <List sx={{ width: 250 }} onClick={onClose}>
+      <ListItem button component={Link} to="/dashboard">
+        <ListItemText primary="Dashboard" />
+      </ListItem>
+      <ListItem button component={Link} to="/profile">
+        <ListItemText primary="Profile" />
+      </ListItem>
+    </List>
+  </Drawer>
+);
+
+export default Sidebar;

--- a/src/components/__tests__/ExampleButton.test.tsx
+++ b/src/components/__tests__/ExampleButton.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExampleButton from '../ExampleButton';
+
+test('calls onClick when clicked', () => {
+  const handleClick = jest.fn();
+  render(<ExampleButton label="Test" onClick={handleClick} />);
+  fireEvent.click(screen.getByText('Test'));
+  expect(handleClick).toHaveBeenCalled();
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextValue {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [isAuthenticated, setAuth] = useState(false);
+
+  const login = () => setAuth(true);
+  const logout = () => setAuth(false);
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Box, Paper, Typography } from '@mui/material';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { Line } from 'react-chartjs-2';
+import { useDropzone } from 'react-dropzone';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+
+const columns: GridColDef[] = [
+  { field: 'id', headerName: 'ID', width: 70 },
+  { field: 'name', headerName: 'Name', width: 130 },
+];
+
+const rows = [
+  { id: 1, name: 'John' },
+  { id: 2, name: 'Jane' },
+];
+
+const chartData = {
+  labels: ['Jan', 'Feb', 'Mar'],
+  datasets: [
+    {
+      label: 'Example',
+      data: [3, 2, 5],
+      borderColor: '#0057b7',
+    },
+  ],
+};
+
+const Dashboard = () => {
+  const { getRootProps, getInputProps, acceptedFiles } = useDropzone();
+
+  return (
+    <Box p={2}>
+      <Typography variant="h5" gutterBottom>
+        Data Grid
+      </Typography>
+      <Paper sx={{ height: 200, mb: 4 }}>
+        <DataGrid rows={rows} columns={columns} hideFooter />
+      </Paper>
+
+      <Typography variant="h5" gutterBottom>
+        Chart
+      </Typography>
+      <Paper sx={{ p: 2, mb: 4 }}>
+        <Line data={chartData} />
+      </Paper>
+
+      <Typography variant="h5" gutterBottom>
+        File Upload
+      </Typography>
+      <Paper sx={{ p: 2, mb: 4 }} {...getRootProps()}>
+        <input {...getInputProps()} />
+        <p>Drag 'n' drop files here, or click to select files</p>
+        {acceptedFiles.map((file) => (
+          <Typography key={file.name}>{file.name}</Typography>
+        ))}
+      </Paper>
+
+      <Typography variant="h5" gutterBottom>
+        Text Editor
+      </Typography>
+      <Paper sx={{ p: 2 }}>
+        <CKEditor editor={ClassicEditor} data="" />
+      </Paper>
+    </Box>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+const Landing = () => (
+  <Box p={2} textAlign="center">
+    <Typography variant="h4" gutterBottom>
+      Welcome
+    </Typography>
+    <Button variant="contained" component={Link} to="/login">
+      Login
+    </Button>
+  </Box>
+);
+
+export default Landing;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Button, TextField, Box, Paper, Typography } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+
+const Login = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    login();
+    toast.success('Logged in');
+    navigate('/dashboard');
+  };
+
+  return (
+    <Box display="flex" justifyContent="center" mt={8}>
+      <Paper sx={{ p: 4, width: 300 }} component="form" onSubmit={handleSubmit}>
+        <Typography variant="h6" mb={2} textAlign="center">
+          Login
+        </Typography>
+        <TextField
+          label="Email"
+          fullWidth
+          margin="normal"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <TextField
+          label="Password"
+          type="password"
+          fullWidth
+          margin="normal"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+          Login
+        </Button>
+      </Paper>
+    </Box>
+  );
+};
+
+export default Login;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const Profile = () => (
+  <Box p={2}>
+    <Typography variant="h5">Profile Page</Typography>
+  </Box>
+);
+
+export default Profile;

--- a/src/stories/ExampleButton.stories.tsx
+++ b/src/stories/ExampleButton.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ExampleButton from '../components/ExampleButton';
+
+const meta: Meta<typeof ExampleButton> = {
+  title: 'Example/Button',
+  component: ExampleButton,
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleButton>;
+
+export const Primary: Story = {
+  args: {
+    label: 'Click me',
+  },
+};

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,5 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import React, { createContext, useContext, useState } from 'react';
 
 const commonPalette = {
   primary: {
@@ -22,3 +23,29 @@ export const darkTheme = createTheme({
     ...commonPalette,
   },
 });
+
+type ThemeMode = 'light' | 'dark';
+
+const ThemeModeContext = createContext<{ mode: ThemeMode; toggleMode: () => void } | undefined>(
+  undefined
+);
+
+export const ThemeModeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [mode, setMode] = useState<ThemeMode>('light');
+  const toggleMode = () => setMode((m) => (m === 'light' ? 'dark' : 'light'));
+  return (
+    <ThemeModeContext.Provider value={{ mode, toggleMode }}>
+      <ThemeProvider theme={mode === 'light' ? lightTheme : darkTheme}>
+        {children}
+      </ThemeProvider>
+    </ThemeModeContext.Provider>
+  );
+};
+
+export const useThemeMode = () => {
+  const ctx = useContext(ThemeModeContext);
+  if (!ctx) {
+    throw new Error('useThemeMode must be used within ThemeModeProvider');
+  }
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add dashboard, authentication context and protected routes
- include demo components for DataGrid, Chart, file upload and text editor
- wire up header, sidebar and light/dark theme toggle
- configure Storybook with an example button
- document new features and scripts in README

## Testing
- `npx eslint -c .eslintrc.json 'src/**/*.{ts,tsx}'` *(fails: Module needs import assertion)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867739df66c83288465c6ac301d3a71